### PR TITLE
Fixing under/over linking, changelog format

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ libopx_nas_acl_la_SOURCES=src/nas_acl_init.cpp src/nas_acl_table.cpp src/nas_acl
 libopx_nas_acl_la_CPPFLAGS= -D_FILE_OFFSET_BITS=64 -I$(top_srcdir)/inc/opx -I$(includedir)/opx
 libopx_nas_acl_la_CXXFLAGS=-std=c++11
 libopx_nas_acl_la_LDFLAGS=-shared -version-info 1:1:0
-libopx_nas_acl_la_LIBADD=-lopx_common -lopx_nas_ndi -lopx_cps_class_map -lopx_cps_api_common -lopx_logging
+libopx_nas_acl_la_LIBADD=-lopx_common -lopx_nas_ndi -lopx_cps_api_common -lopx_logging -lopx_nas_linux -lopx_nas_common
 
 systemdconfdir=/lib/systemd/system
 systemdconf_DATA = scripts/init/*.service

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,4 +2,4 @@ libopx-nas-acl (1.0.1) main; urgency=medium
 
 	 * Initial release
 
- -- Dell Team <support@dell.com> Mon, 29 Feb 2016 11:12:18 -0800
+ -- Dell Team <support@dell.com>  Mon, 16 Jan 2017 11:12:18 -0800

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libopx-nas-acl
 Section: net
 Priority: optional
 Maintainer: Dell <support@dell.com>
-Build-Depends: debhelper (>= 9),dh-autoreconf,dh-systemd,autotools-dev,libopx-common-dev,libopx-cps-dev,libopx-logging-dev,libopx-nas-common-dev,opx-ndi-api-dev,libopx-nas-ndi-dev
+Build-Depends: debhelper (>= 9),dh-autoreconf,dh-systemd,autotools-dev,libopx-common-dev,libopx-cps-dev,libopx-logging-dev,libopx-nas-common-dev,opx-ndi-api-dev,libopx-nas-ndi-dev,libopx-nas-linux-dev
 Standards-Version: 3.9.3
 Vcs-Browser: https://github.com/open-switch/opx-nas-acl
 Vcs-Git: https://github.com/open-switch/opx-nas-acl.git


### PR DESCRIPTION
- Added library dependency for opx_nas_linux, opx_nas_common
- Removed opx_cps_class_map which may not be used
- Updated changelog