### PR TITLE
Add default ACLs for OSPFv3 protocol packets

### DIFF
--- a/scripts/acl/nas_detail_list.xml
+++ b/scripts/acl/nas_detail_list.xml
@@ -16,6 +16,7 @@
      <table tag="system-flow">
           <allow-match>SRC_IP</allow-match>
           <allow-match>DST_IP</allow-match>
+          <allow-match>DST_IPV6</allow-match>
           <allow-match>DST_MAC</allow-match>
           <allow-match>IP_PROTOCOL</allow-match>
           <allow-match>IP_TYPE</allow-match>
@@ -67,7 +68,7 @@
          </match>
      </entry>
 
-     <entry tag="ospf-all">
+     <entry tag="ospfv2-all">
          <match type="DST_IP">
              <value>
                  <addr>224.0.0.5</addr>
@@ -80,7 +81,7 @@
          </match>
      </entry>
 
-     <entry tag="ospf-all-dr">
+     <entry tag="ospfv2-all-dr">
          <match type="DST_IP">
              <value>
                  <addr>224.0.0.6</addr>
@@ -93,11 +94,50 @@
          </match>
      </entry>
 
-     <entry tag="ospf-ucast">
+     <entry tag="ospfv2-ucast">
          <table>system-flow-stub</table>
          <priority>3</priority>
          <match type="IP_TYPE">
              <value>IPV4ANY</value>
+         </match>
+         <match type="IP_PROTOCOL">
+             <value>
+                 <data>89</data>
+             </value>
+         </match>
+     </entry>
+
+     <entry tag="ospfv3-all">
+         <match type="DST_IPV6">
+             <value>
+                 <addr>ff02::5</addr>
+             </value>
+         </match>
+         <match type="IP_PROTOCOL">
+             <value>
+                 <data>89</data>
+             </value>
+         </match>
+     </entry>
+
+     <entry tag="ospfv3-all-dr">
+         <match type="DST_IPV6">
+             <value>
+                 <addr>ff02::6</addr>
+             </value>
+         </match>
+         <match type="IP_PROTOCOL">
+             <value>
+                 <data>89</data>
+             </value>
+         </match>
+     </entry>
+
+     <entry tag="ospfv3-ucast">
+         <table>system-flow-stub</table>
+         <priority>3</priority>
+         <match type="IP_TYPE">
+             <value>IPV6ANY</value>
          </match>
          <match type="IP_PROTOCOL">
              <value>

--- a/scripts/acl/nas_master_list.xml
+++ b/scripts/acl/nas_master_list.xml
@@ -17,9 +17,12 @@
         <table tag="system-flow" priority="11">
             <entry tag="bgp-src-port"       cpu-q="9" />
             <entry tag="bgp-dst-port"       cpu-q="9" />
-            <entry tag="ospf-all"           cpu-q="9"  action="COPY_TO_CPU"/>
-            <entry tag="ospf-all-dr"        cpu-q="9"  action="COPY_TO_CPU"/>
-            <entry tag="ospf-ucast"         cpu-q="6" />
+            <entry tag="ospfv2-all"         cpu-q="9"  action="COPY_TO_CPU"/>
+            <entry tag="ospfv2-all-dr"      cpu-q="9"  action="COPY_TO_CPU"/>
+            <entry tag="ospfv2-ucast"       cpu-q="6" />
+            <entry tag="ospfv3-all"         cpu-q="9"  action="COPY_TO_CPU"/>
+            <entry tag="ospfv3-all-dr"      cpu-q="9"  action="COPY_TO_CPU"/>
+            <entry tag="ospfv3-ucast"       cpu-q="6" />
             <entry tag="icmp"               cpu-q="4" />
             <entry tag="arp-reply"          cpu-q="6"  action="COPY_TO_CPU"/>
             <entry tag="arp-request"        cpu-q="5"  action="COPY_TO_CPU"/>


### PR DESCRIPTION
When started an OPX system comes up with ACLs that trap OSPFv2 protocol packets to CPU and therefore support  running an OSPFv2 stack.  However, corresponding ACLs for the IPv6 version of the OSPF protocol do not exist.

This commit adds them.

Tested that after reboot all configured ACLs are created and OSPFv3 application running on OPX can establish adjacencies with other OSPFv3 routers.